### PR TITLE
chore: update references to build-definitions repo

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -167,5 +167,5 @@ jobs:
         }
 
         GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${APP_INSTALL_ID}/access_tokens" | jq -r .token) \
-        ./hack/create-pr.sh git@github.com:enterprise-contract/build-definitions.git ../build-definitions
+        ./hack/create-pr.sh git@github.com:conforma/build-definitions.git ../build-definitions
       working-directory: infra-deployments-ci


### PR DESCRIPTION
This commit updates references to the build-definitions repository form `enterprise-contract/build-definitions` to `conforma/build-definitions`.

Ref: EC-1122