### PR TITLE
Fix missing line break in policy tag job

### DIFF
--- a/.github/workflows/konflux-policy.yaml
+++ b/.github/workflows/konflux-policy.yaml
@@ -38,9 +38,7 @@ jobs:
           echo "Updating quay.io/${repo}:konflux"
           skopeo copy --all --digestfile image.digest \
             docker://quay.io/${repo}:latest docker://quay.io/${repo}:konflux
-
-          echo -n "Image Digest: "
-          cat image.digest
+          echo "Image digest: $(cat image.digest)"
         done
 
     - name: Tag latest task policy
@@ -51,7 +49,5 @@ jobs:
           echo "Updating quay.io/${repo}:konflux"
           skopeo copy --all --digestfile image.digest \
             docker://quay.io/${repo}:latest docker://quay.io/${repo}:konflux
-
-          echo -n "Image Digest: "
-          cat image.digest
+          echo "Image digest: $(cat image.digest)"
         done


### PR DESCRIPTION
Because there's no line break in the image.digest file we get this in the job log:

    ...
    Image Digest: sha256:fe1e3e0dceb9dcc5242e4c73ec1fca62322b5adf83846067d9fe11a1fe65fae3Updating quay.io/conforma/release-policy:konflux
    ...