### PR TITLE
Update APP_INSTALL_ID in create-pr workflow

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -88,7 +88,7 @@ jobs:
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-        APP_INSTALL_ID: 32872589
+        APP_INSTALL_ID: ${{ secrets.APP_INSTALL_ID }}
       run: |
         set -o errexit
         set -o pipefail
@@ -152,7 +152,7 @@ jobs:
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_BUILD_DEFINITIONS }}
-        APP_INSTALL_ID: 32872589
+        APP_INSTALL_ID: ${{ secrets.APP_INSTALL_ID }}
       run: |
         set -o errexit
         set -o pipefail


### PR DESCRIPTION
I decided to use a secret even though it's maybe not that secret.

Secret is defined here:
https://github.com/organizations/conforma/settings/secrets/actions

You can find the number here:
https://github.com/organizations/conforma/settings/installations If you click Configure next to EC Automation, the id is in the url.

Ref: https://issues.redhat.com/browse/EC-1372