### PR TITLE
Rework recent app install id change

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -88,7 +88,7 @@ jobs:
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-        APP_INSTALL_ID: ${{ secrets.APP_INSTALL_ID }}
+        APP_INSTALL_ID: ${{ vars.INFRA_DEPLOYMENTS_APP_INSTALL_ID }}
       run: |
         set -o errexit
         set -o pipefail
@@ -152,7 +152,7 @@ jobs:
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_BUILD_DEFINITIONS }}
-        APP_INSTALL_ID: ${{ secrets.APP_INSTALL_ID }}
+        APP_INSTALL_ID: ${{ vars.INFRA_DEPLOYMENTS_APP_INSTALL_ID }}
       run: |
         set -o errexit
         set -o pipefail


### PR DESCRIPTION
See also this (but you might not have permission):
* https://github.com/redhat-appstudio/infra-deployments/settings/installations

Long story:
- I thought I needed a new app install id, so I changed it in the recent PR #172, but actually the original install id was correct.
- I now think I only needed a new deploy key, which I also did create.
- So this is effectively a revert of 8c72e37, but I decided this time to use a var.

Ref: https://issues.redhat.com/browse/EC-1372