### PR TITLE
refactor(ci): remove build-definitions PR creation

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -3,14 +3,6 @@ name: create-pr
 
 on:
   workflow_dispatch:
-    inputs:
-      run_for:
-        type: choice
-        description: What to update
-        options:
-        - infra-deployments
-        - build-definitions
-        - all
   schedule:
     # At 09:00 UTC on Tuesday
     - cron: '0 9 * * 2'
@@ -20,9 +12,6 @@ permissions:
 
 jobs:
   create-infra-deployments-pr:
-    # also run by default
-    if: >
-      inputs.run_for == 'infra-deployments' || inputs.run_for == 'all' || inputs.run_for == ''
     runs-on: ubuntu-latest
 
     steps:
@@ -104,68 +93,4 @@ jobs:
 
         GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${APP_INSTALL_ID}/access_tokens" | jq -r .token) \
         ./hack/create-pr.sh git@github.com:conforma/infra-deployments.git ../infra-deployments
-      working-directory: infra-deployments-ci
-
-  create-build-definitions-pr:
-    if: >
-      inputs.run_for == 'build-definitions' || inputs.run_for == 'all'
-    runs-on: ubuntu-latest
-
-    steps:
-
-    - name: Harden Runner
-      uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-      with:
-        egress-policy: audit
-        disable-telemetry: true
-
-    - name: Checkout build-definitions
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: konflux-ci/build-definitions
-        ref: main
-        path: build-definitions
-
-    - name: Checkout ec
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: conforma/cli
-        ref: main
-        path: cli
-
-    - name: Update ec
-      env:
-        KEEP_TAG: 1
-      run: ./hack/update-build-definitions.sh ../build-definitions
-      working-directory: cli
-
-    - name: Display diff
-      run: git diff
-      working-directory: build-definitions
-
-    - name: Checkout infra-deployments-ci
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        path: infra-deployments-ci
-
-    - name: Create PR in build-definitions
-      env:
-        EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_BUILD_DEFINITIONS }}
-        APP_INSTALL_ID: ${{ vars.INFRA_DEPLOYMENTS_APP_INSTALL_ID }}
-      run: |
-        set -o errexit
-        set -o pipefail
-        set -o nounset
-
-        function createJWT() {
-          local header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 | sed s/\+/-/ | sed -E s/=+$//)
-          local now_utc=$(date --utc +%s)
-          local payload=$(echo -n '{"iat":'$((now_utc - 60))',"exp":'$((now_utc + 120))',"iss":245286}' | base64 | sed s/\+/-/ | sed -E s/=+$//)
-          local signature=$(echo -n "${header}.${payload}" | openssl dgst -sha256 -binary -sign <(echo "${EC_AUTOMATION_KEY}")| base64 | tr -d '\n=' | tr -- '+/' '-_')
-          echo "${header}.${payload}.${signature}"
-        }
-
-        GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${APP_INSTALL_ID}/access_tokens" | jq -r .token) \
-        ./hack/create-pr.sh git@github.com:conforma/build-definitions.git ../build-definitions
       working-directory: infra-deployments-ci


### PR DESCRIPTION
This commit removes the create-build-defintions-pr job and simplifies workflow triggers since build-definition PR creation is no longer needed as it is provided by Mintmaker / Renovate. This eliminates the `run_for` parameter with its infra-deployment/build-definition/all options and removes conditional logic from the remaining job.

Ref: EC-1376